### PR TITLE
添加了 requestPath 配置项，支持自定义 Ollama 服务器地址

### DIFF
--- a/info.json
+++ b/info.json
@@ -6,6 +6,11 @@
   "homepage": "https://github.com/Strivy-ZSY/pot-app-recognize-plugin-ollama",
   "needs": [
     {
+      "key": "requestPath",
+      "display": "请求地址",
+      "type": "input"
+    },
+    {
       "key": "model",
       "display": "模型",
       "type": "input"

--- a/main.js
+++ b/main.js
@@ -51,6 +51,7 @@ async function recognize(base64, lang, options) {
     };
 
     // 打印请求信息以便调试
+    console.log("Request URL:", requestPath);
     console.log("Request Body:", JSON.stringify(body, null, 2));
     console.log("Request Headers:", headers);
 
@@ -74,6 +75,6 @@ async function recognize(base64, lang, options) {
         }
     } catch (error) {
         console.error("Request failed:", error);
-        throw new Error(`Request failed: ${error.message}`);
+        throw new Error(`Request failed: ${error.message}\nURL: ${requestPath}`);
     }
 }


### PR DESCRIPTION
此 PR 添加了 requestPath输入框配置项，允许用户自定义 Ollama 服务器的请求地址。这使得插件不仅支持本地部署的 Ollama，还能方便地连接到局域网中的其他设备或远程服务器。